### PR TITLE
video merge & save 기능 구현

### DIFF
--- a/WorksMovie/WMPlayAndStoreVideoViewController.m
+++ b/WorksMovie/WMPlayAndStoreVideoViewController.m
@@ -9,11 +9,13 @@
 #import "WMPlayAndStoreVideoViewController.h"
 #import "WMShowVideosViewController.h"
 #import "WMPlayVideo.h"
+#import "WMStoreVideo.h"
 
 @interface WMPlayAndStoreVideoViewController ()
 
 @property (nonatomic, strong) WMModelManager *modelManager;
 @property (nonatomic, strong) WMPlayVideo *playVideo;
+@property (nonatomic, strong) WMStoreVideo *storeVideo;
 @property (nonatomic, strong) UIView *videoView;
 @property (nonatomic, strong) UIButton *playVideoButton;
 @property (nonatomic, strong) UIView *videoStoreMenuContainerView;
@@ -176,7 +178,9 @@
 #pragma mark - Store Video Button Event Handler Methods
 
 - (void)storeVideoButtonClicked:(UIButton *)sender {
-    NSLog(@"storeVideoButton clicked");
+    self.storeVideo = [[WMStoreVideo alloc] initWithModelManager:self.modelManager];
+    [self.storeVideo mergeVideo];
+    [self.storeVideo storeVideo];
 }
 
 @end

--- a/WorksMovie/WMRecordVideo.m
+++ b/WorksMovie/WMRecordVideo.m
@@ -30,7 +30,7 @@
 
 - (void)setupCaptureSession {
     self.session = [[AVCaptureSession alloc] init];
-    self.session.sessionPreset = AVCaptureSessionPresetMedium;
+    self.session.sessionPreset = AVCaptureSessionPresetHigh;
     
     //카메라에 대한 AVCaptureDevice로 인스턴스 생성하고 AVCaptureDeviceInput을 생성한 후 세션에 추가한다.
     AVCaptureDevice *inputDevice = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo];

--- a/WorksMovie/WMStoreVideo.h
+++ b/WorksMovie/WMStoreVideo.h
@@ -7,7 +7,12 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "WMModelManager.h"
 
 @interface WMStoreVideo : NSObject
+
+- (instancetype)initWithModelManager:(WMModelManager *)modelManager;
+- (void)mergeVideo;
+- (void)storeVideo;
 
 @end

--- a/WorksMovie/WMStoreVideo.m
+++ b/WorksMovie/WMStoreVideo.m
@@ -44,6 +44,10 @@
     
     self.composition = [[AVMutableComposition alloc] init];
     AVMutableCompositionTrack *compositionVideoTrack = [self.composition addMutableTrackWithMediaType:AVMediaTypeVideo preferredTrackID:kCMPersistentTrackID_Invalid];
+    
+    CGAffineTransform transform = CGAffineTransformMakeRotation((90 * M_PI ) / 180);
+    compositionVideoTrack.preferredTransform = transform;
+    
     AVMutableCompositionTrack *soundtrackTrack = [self.composition addMutableTrackWithMediaType:AVMediaTypeAudio preferredTrackID:kCMPersistentTrackID_Invalid];
     CMTime insertTime = kCMTimeZero;
     

--- a/WorksMovie/WMStoreVideo.m
+++ b/WorksMovie/WMStoreVideo.m
@@ -6,8 +6,105 @@
 //  Copyright © 2016년 worksmobile. All rights reserved.
 //
 
+#import <AVFoundation/AVFoundation.h>
+#import <Photos/Photos.h>
 #import "WMStoreVideo.h"
+
+@interface WMStoreVideo ()
+
+@property (nonatomic, strong) WMModelManager *modelManager;
+@property (nonatomic, strong) NSMutableArray *assets;
+@property (nonatomic, strong) AVMutableComposition *composition;
+
+@end
 
 @implementation WMStoreVideo
 
+- (instancetype)initWithModelManager:(WMModelManager *)modelManager {
+    self = [super init];
+    
+    if(self) {
+        self.modelManager = modelManager;
+    }
+    return self;
+}
+
+// modalManager의 videoData들을(촬영된 비디오들의 url) asset으로 생성
+- (void)setupAssetsOfVideoDatas {
+    self.assets = [[NSMutableArray alloc] init];
+    
+    for(int i = 0 ; i < [self.modelManager.videoDatas count] ; i++) {
+        [self.assets addObject:[AVAsset assetWithURL:[(WMModel *)self.modelManager.videoDatas[i] videoURL]]];
+    }
+}
+
+// 촬영된 1개 이상의 비디오를 하나로 병합시키는 기능
+- (void)mergeVideo {
+    [self setupAssetsOfVideoDatas];
+    
+    self.composition = [[AVMutableComposition alloc] init];
+    AVMutableCompositionTrack *compositionVideoTrack = [self.composition addMutableTrackWithMediaType:AVMediaTypeVideo preferredTrackID:kCMPersistentTrackID_Invalid];
+    AVMutableCompositionTrack *soundtrackTrack = [self.composition addMutableTrackWithMediaType:AVMediaTypeAudio preferredTrackID:kCMPersistentTrackID_Invalid];
+    CMTime insertTime = kCMTimeZero;
+    
+    for(AVAsset *videoAsset in self.assets){    //촬영된 비디오의 asset들을 돌면서 각 compositionVideoTrack과 soundtrackTrack을 하나의 track으로 연속해 이어붙임
+        [compositionVideoTrack insertTimeRange:CMTimeRangeMake(kCMTimeZero, videoAsset.duration) ofTrack:[[videoAsset tracksWithMediaType:AVMediaTypeVideo] objectAtIndex:0] atTime:insertTime error:nil];
+        [soundtrackTrack insertTimeRange:CMTimeRangeMake(kCMTimeZero, videoAsset.duration) ofTrack:[[videoAsset tracksWithMediaType:AVMediaTypeAudio] objectAtIndex:0] atTime:insertTime error:nil];
+        
+        insertTime = CMTimeAdd(insertTime, videoAsset.duration); // 다음 insert를 위해 insertTime을 갱신
+    }
+}
+
+// 저장된 파일을 내보낼 path생성
+- (NSString *)outputPath {
+    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+    NSString *documentsDirectory = [paths objectAtIndex:0];
+    NSString *uuid = [[NSUUID UUID] UUIDString];
+    NSString *outputVideoPath =  [documentsDirectory stringByAppendingPathComponent:
+                                  [NSString stringWithFormat:@"%@%@", uuid, @".mov"]];
+    return outputVideoPath;
+}
+
+//카메라 롤에 merge된 비디오를 저장하는 메소드 
+- (void)storeVideo {
+    NSString *outputVideoPath = [self outputPath];
+    NSURL *outputVideoURL = [NSURL fileURLWithPath:outputVideoPath];
+    
+    AVAssetExportSession *exporter = [[AVAssetExportSession alloc] initWithAsset:self.composition presetName:AVAssetExportPresetHighestQuality];
+    
+    exporter.outputURL=outputVideoURL;
+    exporter.outputFileType = AVFileTypeQuickTimeMovie;
+    exporter.shouldOptimizeForNetworkUse = YES;
+    
+    [exporter exportAsynchronouslyWithCompletionHandler:^{
+        NSLog (@"created exporter. supportedFileTypes: %@", exporter.supportedFileTypes);
+        switch ([exporter status]) {
+            case AVAssetExportSessionStatusFailed:
+                NSLog(@"Export failed: %@", [[exporter error] localizedDescription]);
+                break;
+            case AVAssetExportSessionStatusCancelled:
+                NSLog(@"Export canceled");
+                break;
+            default:
+                break;
+        }
+        if(UIVideoAtPathIsCompatibleWithSavedPhotosAlbum(outputVideoPath)) {
+            NSLog(@"video path is compatible with saved photo album");
+        }
+        UISaveVideoAtPathToSavedPhotosAlbum(outputVideoPath, self, @selector(video:didFinishSavingWithError:contextInfo:), nil); // 카메라 롤에 저장
+    }];
+    
+}
+
+- (void)video:(NSString*)videoPath didFinishSavingWithError:(NSError*)error contextInfo:(void*)contextInfo {
+    if (error) {
+        NSLog(@"error");
+    }
+    else {
+        NSLog(@"finish saving");
+    }
+}
+     
+
+     
 @end


### PR DESCRIPTION
#### bug

카메라 롤에 저장 후 포토 앨범에서 저장된 비디오를 재생하면 비디오가 rotate 되어서 재생.
썸네일을 추출할 때 [imageGenerator setAppliesPreferredTrackTransform:true]; 이 코드를 추가해 주지 않았을 때, rotate 된 썸네일이 보였던 것 과 비슷한 맥락의 문제일 것이라고 판단됩니다.
아무래도 비디오가 촬영될 때 rotate되어 저장되는지 metadata를 통해 확인해 봐야 할 것 같습니다.
